### PR TITLE
SOCKS support

### DIFF
--- a/src/shared/js/background/pac.js
+++ b/src/shared/js/background/pac.js
@@ -48,12 +48,12 @@ export const getPacScript = ({ domains = [], proxyServerURI }) => {
         
         // Proxy *.onion and *.i2p domains.
         if (shExpMatch(host, '*.onion') || shExpMatch(host, '*.i2p')) {
-          return 'HTTPS ${proxyServerURI};';
+          return '${proxyServerURI};';
         }
 
         // Return result
         if (isHostBlocked(domains, host)) {
-          return 'HTTPS ${proxyServerURI};';
+          return '${proxyServerURI};';
         } else {
           return 'DIRECT';
         }

--- a/src/shared/js/background/proxy.js
+++ b/src/shared/js/background/proxy.js
@@ -17,7 +17,7 @@ class ProxyManager {
       console.warn('Using custom proxy for PAC.')
       return customProxyServerURI
     }
-    return proxyServerURI
+    return `HTTPS ${proxyServerURI}`
   }
 
   async requestIncognitoAccess () {

--- a/src/shared/pages/proxy-options.html
+++ b/src/shared/pages/proxy-options.html
@@ -58,7 +58,7 @@
             <input type="text"
                    id="proxyServerInput"
                    class="input-proxy"
-                   placeholder="username:password@hostname:port">
+                   placeholder="[HTTP, HTTPS, SOCKS4, SOCKS5] username:password@hostname:port">
 
             <button class="btn btn-dark" id="saveCustomProxyButton">
               <span class="btn__text" data-i18n-key="saveCustomProxyButton"></span>


### PR DESCRIPTION
пример, как можно добавить поддержку любых прокси, а не только HTTPS. Я бы ещё сделал выпадающий список с выбором типа прокси, но мне просто лень этим заниматься, и так работает.