### PR TITLE
Fix update title in dark theme

### DIFF
--- a/src/shared/css/options.css
+++ b/src/shared/css/options.css
@@ -1201,4 +1201,8 @@ kbd {
     .invalid-input {
         border: 1px solid #9e5757 !important;
     }
+
+    .update_available {
+        color-scheme: light;
+    }
 }


### PR DESCRIPTION
After this change, the `Update available` text will be visible in the dark theme, and the text will also have the correct color when highlighted.