### PR TITLE
fix(browser-api): improve browser detection logic

### DIFF
--- a/src/shared/js/background/browser-api.js
+++ b/src/shared/js/background/browser-api.js
@@ -25,7 +25,7 @@ export const getBrowserInfo = () => {
  * @returns {*}
  */
 const getBrowser = () => {
-  if (typeof browser !== 'undefined') {
+  if (typeof browser !== 'undefined' && browser.runtime?.getBrowserInfo) {
     browser.isFirefox = true
     return browser
   }

--- a/src/shared/js/background/browser-api.js
+++ b/src/shared/js/background/browser-api.js
@@ -22,15 +22,19 @@ export const getBrowserInfo = () => {
 
 /**
  * Returns the browser's API object.
- * @returns {*}
+ * @returns {Promise<*>}
  */
-const getBrowser = () => {
+const getBrowser = async () => {
   if (typeof browser !== 'undefined' && browser.runtime?.getBrowserInfo) {
-    browser.isFirefox = true
-    return browser
+    const { name } = await browser.runtime.getBrowserInfo()
+
+    if (name === 'Firefox') {
+      browser.isFirefox = true
+      return browser
+    }
   }
   chrome.isFirefox = false
   return chrome
 }
 
-export default getBrowser()
+export default await getBrowser()

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,6 +29,9 @@ const contentSecurityPolicy = {
 }
 
 const webWorkerConfig = {
+  experiments: {
+    topLevelAwait: true,
+  },
   mode: NODE_ENV,
   target: isFirefox ? 'webworker' : 'web',
   entry: {
@@ -80,6 +83,9 @@ const webWorkerConfig = {
 }
 
 const webConfig = {
+  experiments: {
+    topLevelAwait: true,
+  },
   mode: NODE_ENV,
   // Also see: https://webpack.js.org/configuration/devtool/#devtool
   target: 'web',


### PR DESCRIPTION
Some Chromium-based browsers (e.g. Edge, Brave) now expose a global `browser` object in service workers, which caused the extension to mistakenly detect them as Firefox. Added a check for `browser.runtime.getBrowserInfo` to ensure correct Firefox detection.

Fixes #836